### PR TITLE
Add keep_audio setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This repository provides a simple Python script for recording a meeting on macOS
 - `openai_model` – OpenAI chat model to use (default `gpt-3.5-turbo`).
 - `gemini_model` – Gemini model name (default `gemini-pro`).
 - `output_dir` – folder where audio, transcripts, and notes are stored.
+- `keep_audio` – set to `false` to delete the recording after transcription.
 
 ## Capturing Browser and Microphone Audio with BlackHole
 

--- a/meeting_notes.py
+++ b/meeting_notes.py
@@ -140,5 +140,12 @@ def main():
     save_output(notes, notes_path, cfg.get("output_format", "text"))
     print(f"Notes saved to {notes_path}")
 
+    if not cfg.get("keep_audio", True):
+        try:
+            os.remove(audio_file)
+            print(f"Deleted audio file {audio_file}")
+        except OSError as e:
+            print(f"Failed to delete audio file: {e}")
+
 if __name__ == "__main__":
     main()

--- a/settings.json
+++ b/settings.json
@@ -8,5 +8,6 @@
   "openai_model": "gpt-4o",
   "gemini_model": "gemini-pro",
   "output_format": "markdown",
-  "output_dir": "/Users/bwdude/Documents/obsidian-vault/meetings"
+  "output_dir": "/Users/bwdude/Documents/obsidian-vault/meetings",
+  "keep_audio": false
 }


### PR DESCRIPTION
## Summary
- add `keep_audio` setting to delete audio after processing
- update script to remove audio when `keep_audio` is false
- document new option in README

## Testing
- `python -m py_compile meeting_notes.py`


------
https://chatgpt.com/codex/tasks/task_e_6866735b5c648323b8abade753fd81a8