### PR TITLE
Fix whispercpp decode error

### DIFF
--- a/meeting_notes.py
+++ b/meeting_notes.py
@@ -88,7 +88,7 @@ def transcribe_audio(
             raise SystemExit(
                 "whisper-cli not found. Build whisper.cpp and set 'whispercpp_binary' in settings.json"
             )
-        return out.decode().strip()
+        return out.decode("utf-8", errors="replace").strip()
 
     device = "mps" if torch.has_mps else "cpu"
     model = whisper.load_model(model_size, device=device)


### PR DESCRIPTION
## Summary
- avoid UnicodeDecodeError when reading `whisper-cli` output

## Testing
- `python -m py_compile meeting_notes.py`

------
https://chatgpt.com/codex/tasks/task_e_6867aa11673c8323a524fa648c088550