### PR TITLE
Improve notes prompt with meeting name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,12 @@ This repository provides a simple Python script for recording a meeting on macOS
    ```
    path/to/team_sync.wav
    path/to/notes_team_sync.md
-   path/to/transcript_team_sync.txt
-   ```
+  path/to/transcript_team_sync.txt
+  ```
+
+The folder name (taken from the Calendar event title or the provided audio file
+name) is also passed to the language model to help it understand what the
+meeting is about.
 
 ## Configuration
 
@@ -110,7 +114,8 @@ This repository provides a simple Python script for recording a meeting on macOS
 - `use_calendar_title` – if `true` on macOS, the script uses the current
   Calendar event title for the output folder name instead of a timestamp. This
   requires the [`icalBuddy`](https://github.com/ali-rantakari/icalBuddy) utility
-  to be installed.
+  to be installed. The folder name is also provided to the LLM prompt as the
+  meeting title for additional context.
 
 
 ## Capturing Browser and Microphone Audio with BlackHole

--- a/meeting_notes.py
+++ b/meeting_notes.py
@@ -180,15 +180,23 @@ def transcribe_audio(
     result = model.transcribe(audio_path, language=language)
     return result["text"].strip()
 
-def summarize_text(text, sentences=5, provider="openai", model="gpt-3.5-turbo", language="en"):
+def summarize_text(
+    text,
+    sentences=5,
+    provider="openai",
+    model="gpt-3.5-turbo",
+    language="en",
+    meeting_name=None,
+):
     lang_name = language_name(language)
     if provider == "openai":
         api_key = os.environ.get("OPENAI_API_KEY")
         if not api_key:
             raise RuntimeError("OPENAI_API_KEY environment variable not set")
         client = openai.OpenAI(api_key=api_key)
+        name_hint = f" titled '{meeting_name}'" if meeting_name else ""
         prompt = (
-            "Summarize the following meeting transcript. "
+            f"Summarize the following meeting transcript{name_hint}. "
             "- First, provide a concise summary in bullet points. "
             "- Then, list all action items separately, each with the responsible person (if mentioned). "
             f"The most probable meeting language code is {lang_name}. "
@@ -211,8 +219,9 @@ def summarize_text(text, sentences=5, provider="openai", model="gpt-3.5-turbo", 
         if not api_key:
             raise RuntimeError("GOOGLE_API_KEY environment variable not set")
         genai.configure(api_key=api_key)
+        name_hint = f" titled '{meeting_name}'" if meeting_name else ""
         prompt = (
-            "Summarize the following meeting transcript into "
+            f"Summarize the following meeting transcript{name_hint} into "
             f"{sentences} concise bullet points. "
             f"Write the answer in {lang_name}."
         )
@@ -375,6 +384,7 @@ def main(argv=None):
             provider,
             cfg.get(model_key, "gpt-3.5-turbo" if provider == "openai" else "gemini-pro"),
             cfg.get("language", "en"),
+            meeting_name=base_name,
         )
 
         links = ""


### PR DESCRIPTION
## Summary
- factor meeting name into `summarize_text`
- pass meeting name from `main`
- document how the folder name is used as context

## Testing
- `python -m py_compile meeting_notes.py`

------
https://chatgpt.com/codex/tasks/task_e_6870d28d170c8323bede4f397999a5b6